### PR TITLE
Proposal: add support to xml:space attribute

### DIFF
--- a/node.go
+++ b/node.go
@@ -69,7 +69,7 @@ func (n *Node) InnerText() string {
 
 func (n *Node) sanitizedData(preserveSpaces bool) string {
 	if preserveSpaces {
-		return n.Data
+		return strings.Trim(n.Data, "\n\t")
 	}
 	return strings.TrimSpace(n.Data)
 }

--- a/node_test.go
+++ b/node_test.go
@@ -1,6 +1,7 @@
 package xmlquery
 
 import (
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -361,6 +362,11 @@ func TestOutputXMLWithSpaceParent(t *testing.T) {
 	if g := doc.OutputXML(true); strings.Index(g, expected) == -1 {
 		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
 	}
+
+	output := html.UnescapeString(doc.OutputXML(true))
+	if strings.Contains(output, "\n") {
+		t.Errorf("the outputted xml contains newlines")
+	}
 	t.Log(n.OutputXML(false))
 }
 
@@ -379,6 +385,11 @@ func TestOutputXMLWithSpaceDirect(t *testing.T) {
 	expected := `<name xml:space="preserve"> Robert </name>`
 	if g := doc.OutputXML(false); strings.Index(g, expected) == -1 {
 		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+
+	output := html.UnescapeString(doc.OutputXML(true))
+	if strings.Contains(output, "\n") {
+		t.Errorf("the outputted xml contains newlines")
 	}
 	t.Log(n.OutputXML(false))
 }
@@ -399,6 +410,11 @@ func TestOutputXMLWithSpaceOverwrittenToPreserve(t *testing.T) {
 	if g := n.OutputXML(false); strings.Index(g, expected) == -1 {
 		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
 	}
+
+	output := html.UnescapeString(doc.OutputXML(true))
+	if strings.Contains(output, "\n") {
+		t.Errorf("the outputted xml contains newlines")
+	}
 	t.Log(n.OutputXML(false))
 }
 
@@ -417,6 +433,11 @@ func TestOutputXMLWithSpaceOverwrittenToDefault(t *testing.T) {
 	expected := `<name xml:space="default">Robert</name>`
 	if g := doc.OutputXML(false); strings.Index(g, expected) == -1 {
 		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+
+	output := html.UnescapeString(doc.OutputXML(true))
+	if strings.Contains(output, "\n") {
+		t.Errorf("the outputted xml contains newlines")
 	}
 	t.Log(n.OutputXML(false))
 }

--- a/node_test.go
+++ b/node_test.go
@@ -344,3 +344,79 @@ func TestOutputXMLWithCommentNode(t *testing.T) {
 		t.Fatal("missing some comment-node")
 	}
 }
+
+func TestOutputXMLWithSpaceParent(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list>
+		<student xml:space="preserve">
+			<name> Robert </name>
+			<grade>A+</grade>
+		</student>
+	</class_list>`
+	doc, _ := Parse(strings.NewReader(s))
+	t.Log(doc.OutputXML(true))
+
+	n := FindOne(doc, "/class_list/student/name")
+	expected := "<name> Robert </name>"
+	if g := doc.OutputXML(true); strings.Index(g, expected) == -1 {
+		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+	t.Log(n.OutputXML(false))
+}
+
+func TestOutputXMLWithSpaceDirect(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list>
+		<student>
+			<name xml:space="preserve"> Robert </name>
+			<grade>A+</grade>
+		</student>
+	</class_list>`
+	doc, _ := Parse(strings.NewReader(s))
+	t.Log(doc.OutputXML(true))
+
+	n := FindOne(doc, "/class_list/student/name")
+	expected := `<name xml:space="preserve"> Robert </name>`
+	if g := doc.OutputXML(false); strings.Index(g, expected) == -1 {
+		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+	t.Log(n.OutputXML(false))
+}
+
+func TestOutputXMLWithSpaceOverwrittenToPreserve(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list>
+		<student xml:space="default">
+			<name xml:space="preserve"> Robert </name>
+			<grade>A+</grade>
+		</student>
+	</class_list>`
+	doc, _ := Parse(strings.NewReader(s))
+	t.Log(doc.OutputXML(true))
+
+	n := FindOne(doc, "/class_list/student")
+	expected := `<name xml:space="preserve"> Robert </name>`
+	if g := n.OutputXML(false); strings.Index(g, expected) == -1 {
+		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+	t.Log(n.OutputXML(false))
+}
+
+func TestOutputXMLWithSpaceOverwrittenToDefault(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list>
+		<student xml:space="preserve">
+			<name xml:space="default"> Robert </name>
+			<grade>A+</grade>
+		</student>
+	</class_list>`
+	doc, _ := Parse(strings.NewReader(s))
+	t.Log(doc.OutputXML(true))
+
+	n := FindOne(doc, "/class_list/student")
+	expected := `<name xml:space="default">Robert</name>`
+	if g := doc.OutputXML(false); strings.Index(g, expected) == -1 {
+		t.Errorf(`expected "%s", obtained "%s"`, expected, g)
+	}
+	t.Log(n.OutputXML(false))
+}


### PR DESCRIPTION
I noticed that the OutputXML function was trimming my text entries even if the _xml:space_ attribute was set to _preserve_.
It is fundamental for my scopes to preserve that spaces so I tried to add the support for this attribute.
I've also used an existing test as template to create new tests for my edits and all seams to work right to me.

With this PR I would like to propose the support for the _xml:space_ attribute.
Hope the implementation is satisfactory.

I would like to take this opportunity to thank you for the good job done with this library.