### PR TITLE
Extract tree traversing from FindOne()

### DIFF
--- a/query.go
+++ b/query.go
@@ -81,12 +81,20 @@ func Find(top *Node, expr string) []*Node {
 }
 
 // FindOne searches the Node that matches by the specified XPath expr,
-// and returns first element of matched.
+// and returns first element matched.
+// Panics if expr is invalid.
 func FindOne(top *Node, expr string) *Node {
 	exp, err := xpath.Compile(expr)
 	if err != nil {
 		panic(err)
 	}
+
+	return FindOneWithExpression(exp, top)
+}
+
+// FindOneWithExpression searches the top Node by the specified XPath expr
+// and returns the first element matched.
+func FindOneWithExpression(exp *xpath.Expr, top *Node) *Node {
 	t := exp.Select(CreateXPathNavigator(top))
 	var elem *Node
 	if t.MoveNext() {


### PR DESCRIPTION
This allows for pre-compiling the expression before calling FindOne() repeatedly and makes any invalid expression handleable.

# use case

We are trying to use this library for running the same xmlquery multiple times. Since the xmlquery is also user-provided we would like to handle any invalid expressions beforehand w/o having to handle panics.
This PR allows us to compile the expression beforehand (and handle nicely) and apply it multiple times to multiple documents easily.
