### PR TITLE
Support for optional configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/antchfx/xmlquery
+
+go 1.13
+
+require (
+	github.com/antchfx/xpath v1.1.4
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/antchfx/xpath v1.1.4 h1:naPIpjBGeT3eX0Vw7E8iyHsY8FGt6EbGdkcd8EZCo+g=
+github.com/antchfx/xpath v1.1.4/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Hi!
I using your awesome package to parse some MDX (JSX inside markdown documents), which requires sometimes a non-strict mode of XML parser.

This patch adds this feature without breaking any contracts by simply adding a public function `ParseWith` with functional options and slightly modifying the private `parse` function.