### PR TITLE
Stream Parser Support - pt1 - add removeFromTree helper

### DIFF
--- a/.snapshots/TestRemove-remove_a_node_that_is_neither_the_first_nor__the_last_child_of_its_parent
+++ b/.snapshots/TestRemove-remove_a_node_that_is_neither_the_first_nor__the_last_child_of_its_parent
@@ -1,0 +1,244 @@
+{
+	"Parent": "ptr:(nil)",
+	"FirstChild": "ptr:(DECL)",
+	"LastChild": "ptr:(ELEM aaa)",
+	"PrevSibling": "ptr:(nil)",
+	"NextSibling": "ptr:(CDATA '\n\t\t')",
+	"Type": "DocumentNode",
+	"Data": "",
+	"Prefix": "",
+	"NamespaceURI": "",
+	"Attr": null,
+	"Level": 0,
+	"#children": [
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(nil)",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "version"
+					},
+					"Value": "1.0"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "encoding"
+					},
+					"Value": "UTF-8"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(DECL)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml-stylesheet",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "type"
+					},
+					"Value": "text/xsl"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "href"
+					},
+					"Value": "style.xsl"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(COMMENT ' root comment here')",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "CommentNode",
+			"Data": " root comment here",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(COMMENT ' root comment here')",
+			"NextSibling": "ptr:(ELEM aaa)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(ELEM bbb)",
+			"LastChild": "ptr:(ELEM ggg)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(nil)",
+			"Type": "ElementNode",
+			"Data": "aaa",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [],
+			"Level": 1,
+			"#children": [
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+					"LastChild": "ptr:(CDATA '\n\t\t\t')",
+					"PrevSibling": "ptr:(nil)",
+					"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+					"Type": "ElementNode",
+					"Data": "bbb",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(ELEM ccc)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t\tbbb child text\n\t\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+							"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+							"Type": "ElementNode",
+							"Data": "ccc",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(ELEM ccc)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM bbb)",
+					"NextSibling": "ptr:(CDATA '\n\t\t')",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t\t')",
+					"NextSibling": "ptr:(ELEM ggg)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t')",
+					"NextSibling": "ptr:(nil)",
+					"Type": "ElementNode",
+					"Data": "ggg",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": []
+				}
+			]
+		}
+	]
+}
+

--- a/.snapshots/TestRemove-remove_a_node_that_is_the_first_but_not_the_last_child_of_its_parent
+++ b/.snapshots/TestRemove-remove_a_node_that_is_the_first_but_not_the_last_child_of_its_parent
@@ -1,0 +1,231 @@
+{
+	"Parent": "ptr:(nil)",
+	"FirstChild": "ptr:(DECL)",
+	"LastChild": "ptr:(ELEM aaa)",
+	"PrevSibling": "ptr:(nil)",
+	"NextSibling": "ptr:(CDATA '\n\t\t')",
+	"Type": "DocumentNode",
+	"Data": "",
+	"Prefix": "",
+	"NamespaceURI": "",
+	"Attr": null,
+	"Level": 0,
+	"#children": [
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(nil)",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "version"
+					},
+					"Value": "1.0"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "encoding"
+					},
+					"Value": "UTF-8"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(DECL)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml-stylesheet",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "type"
+					},
+					"Value": "text/xsl"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "href"
+					},
+					"Value": "style.xsl"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(COMMENT ' root comment here')",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "CommentNode",
+			"Data": " root comment here",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(COMMENT ' root comment here')",
+			"NextSibling": "ptr:(ELEM aaa)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(CDATA '\n\t\t\t')",
+			"LastChild": "ptr:(ELEM ggg)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(nil)",
+			"Type": "ElementNode",
+			"Data": "aaa",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [],
+			"Level": 1,
+			"#children": [
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(nil)",
+					"NextSibling": "ptr:(ELEM ddd)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(ELEM eee)",
+					"LastChild": "ptr:(ELEM eee)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t\t')",
+					"NextSibling": "ptr:(CDATA '\n\t\t')",
+					"Type": "ElementNode",
+					"Data": "ddd",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM ddd)",
+							"FirstChild": "ptr:(ELEM fff)",
+							"LastChild": "ptr:(ELEM fff)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "ElementNode",
+							"Data": "eee",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": [
+								{
+									"Parent": "ptr:(ELEM eee)",
+									"FirstChild": "ptr:(nil)",
+									"LastChild": "ptr:(nil)",
+									"PrevSibling": "ptr:(nil)",
+									"NextSibling": "ptr:(nil)",
+									"Type": "ElementNode",
+									"Data": "fff",
+									"Prefix": "",
+									"NamespaceURI": "",
+									"Attr": [],
+									"Level": 4,
+									"#children": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM ddd)",
+					"NextSibling": "ptr:(ELEM ggg)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t')",
+					"NextSibling": "ptr:(nil)",
+					"Type": "ElementNode",
+					"Data": "ggg",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": []
+				}
+			]
+		}
+	]
+}
+

--- a/.snapshots/TestRemove-remove_a_node_that_is_the_last_but_not_the_first_child_of_its_parent
+++ b/.snapshots/TestRemove-remove_a_node_that_is_the_last_but_not_the_first_child_of_its_parent
@@ -1,0 +1,274 @@
+{
+	"Parent": "ptr:(nil)",
+	"FirstChild": "ptr:(DECL)",
+	"LastChild": "ptr:(ELEM aaa)",
+	"PrevSibling": "ptr:(nil)",
+	"NextSibling": "ptr:(CDATA '\n\t\t')",
+	"Type": "DocumentNode",
+	"Data": "",
+	"Prefix": "",
+	"NamespaceURI": "",
+	"Attr": null,
+	"Level": 0,
+	"#children": [
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(nil)",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "version"
+					},
+					"Value": "1.0"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "encoding"
+					},
+					"Value": "UTF-8"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(DECL)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml-stylesheet",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "type"
+					},
+					"Value": "text/xsl"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "href"
+					},
+					"Value": "style.xsl"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(COMMENT ' root comment here')",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "CommentNode",
+			"Data": " root comment here",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(COMMENT ' root comment here')",
+			"NextSibling": "ptr:(ELEM aaa)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(ELEM bbb)",
+			"LastChild": "ptr:(CDATA '\n\t\t')",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(nil)",
+			"Type": "ElementNode",
+			"Data": "aaa",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [],
+			"Level": 1,
+			"#children": [
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+					"LastChild": "ptr:(CDATA '\n\t\t\t')",
+					"PrevSibling": "ptr:(nil)",
+					"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+					"Type": "ElementNode",
+					"Data": "bbb",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(ELEM ccc)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t\tbbb child text\n\t\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+							"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+							"Type": "ElementNode",
+							"Data": "ccc",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(ELEM ccc)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM bbb)",
+					"NextSibling": "ptr:(ELEM ddd)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(ELEM eee)",
+					"LastChild": "ptr:(ELEM eee)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t\t')",
+					"NextSibling": "ptr:(CDATA '\n\t\t')",
+					"Type": "ElementNode",
+					"Data": "ddd",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM ddd)",
+							"FirstChild": "ptr:(ELEM fff)",
+							"LastChild": "ptr:(ELEM fff)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "ElementNode",
+							"Data": "eee",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": [
+								{
+									"Parent": "ptr:(ELEM eee)",
+									"FirstChild": "ptr:(nil)",
+									"LastChild": "ptr:(nil)",
+									"PrevSibling": "ptr:(nil)",
+									"NextSibling": "ptr:(nil)",
+									"Type": "ElementNode",
+									"Data": "fff",
+									"Prefix": "",
+									"NamespaceURI": "",
+									"Attr": [],
+									"Level": 4,
+									"#children": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM ddd)",
+					"NextSibling": "ptr:(nil)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				}
+			]
+		}
+	]
+}
+

--- a/.snapshots/TestRemove-remove_a_node_that_is_the_only_child_of_its_parent
+++ b/.snapshots/TestRemove-remove_a_node_that_is_the_only_child_of_its_parent
@@ -1,0 +1,258 @@
+{
+	"Parent": "ptr:(nil)",
+	"FirstChild": "ptr:(DECL)",
+	"LastChild": "ptr:(ELEM aaa)",
+	"PrevSibling": "ptr:(nil)",
+	"NextSibling": "ptr:(CDATA '\n\t\t')",
+	"Type": "DocumentNode",
+	"Data": "",
+	"Prefix": "",
+	"NamespaceURI": "",
+	"Attr": null,
+	"Level": 0,
+	"#children": [
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(nil)",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "version"
+					},
+					"Value": "1.0"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "encoding"
+					},
+					"Value": "UTF-8"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(DECL)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml-stylesheet",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "type"
+					},
+					"Value": "text/xsl"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "href"
+					},
+					"Value": "style.xsl"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(COMMENT ' root comment here')",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "CommentNode",
+			"Data": " root comment here",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(COMMENT ' root comment here')",
+			"NextSibling": "ptr:(ELEM aaa)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(ELEM bbb)",
+			"LastChild": "ptr:(ELEM ggg)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(nil)",
+			"Type": "ElementNode",
+			"Data": "aaa",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [],
+			"Level": 1,
+			"#children": [
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+					"LastChild": "ptr:(CDATA '\n\t\t\t')",
+					"PrevSibling": "ptr:(nil)",
+					"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+					"Type": "ElementNode",
+					"Data": "bbb",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(ELEM ccc)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t\tbbb child text\n\t\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+							"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+							"Type": "ElementNode",
+							"Data": "ccc",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(ELEM ccc)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM bbb)",
+					"NextSibling": "ptr:(ELEM ddd)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t\t')",
+					"NextSibling": "ptr:(CDATA '\n\t\t')",
+					"Type": "ElementNode",
+					"Data": "ddd",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM ddd)",
+					"NextSibling": "ptr:(ELEM ggg)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t')",
+					"NextSibling": "ptr:(nil)",
+					"Type": "ElementNode",
+					"Data": "ggg",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": []
+				}
+			]
+		}
+	]
+}
+

--- a/.snapshots/TestRemove-remove_on_a_root_does_nothing
+++ b/.snapshots/TestRemove-remove_on_a_root_does_nothing
@@ -1,0 +1,288 @@
+{
+	"Parent": "ptr:(nil)",
+	"FirstChild": "ptr:(DECL)",
+	"LastChild": "ptr:(ELEM aaa)",
+	"PrevSibling": "ptr:(nil)",
+	"NextSibling": "ptr:(CDATA '\n\t\t')",
+	"Type": "DocumentNode",
+	"Data": "",
+	"Prefix": "",
+	"NamespaceURI": "",
+	"Attr": null,
+	"Level": 0,
+	"#children": [
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(nil)",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "version"
+					},
+					"Value": "1.0"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "encoding"
+					},
+					"Value": "UTF-8"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(DECL)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "DeclarationNode",
+			"Data": "xml-stylesheet",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [
+				{
+					"Name": {
+						"Space": "",
+						"Local": "type"
+					},
+					"Value": "text/xsl"
+				},
+				{
+					"Name": {
+						"Space": "",
+						"Local": "href"
+					},
+					"Value": "style.xsl"
+				}
+			],
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(DECL)",
+			"NextSibling": "ptr:(COMMENT ' root comment here')",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(CDATA '\n\t\t')",
+			"Type": "CommentNode",
+			"Data": " root comment here",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(nil)",
+			"LastChild": "ptr:(nil)",
+			"PrevSibling": "ptr:(COMMENT ' root comment here')",
+			"NextSibling": "ptr:(ELEM aaa)",
+			"Type": "CharDataNode",
+			"Data": "\n\t\t",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": null,
+			"Level": 1,
+			"#children": []
+		},
+		{
+			"Parent": "ptr:(ROOT)",
+			"FirstChild": "ptr:(ELEM bbb)",
+			"LastChild": "ptr:(ELEM ggg)",
+			"PrevSibling": "ptr:(CDATA '\n\t\t')",
+			"NextSibling": "ptr:(nil)",
+			"Type": "ElementNode",
+			"Data": "aaa",
+			"Prefix": "",
+			"NamespaceURI": "",
+			"Attr": [],
+			"Level": 1,
+			"#children": [
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+					"LastChild": "ptr:(CDATA '\n\t\t\t')",
+					"PrevSibling": "ptr:(nil)",
+					"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+					"Type": "ElementNode",
+					"Data": "bbb",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(ELEM ccc)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t\tbbb child text\n\t\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(CDATA '\n\t\t\t\tbbb child text\n\t\t\t\t')",
+							"NextSibling": "ptr:(CDATA '\n\t\t\t')",
+							"Type": "ElementNode",
+							"Data": "ccc",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": []
+						},
+						{
+							"Parent": "ptr:(ELEM bbb)",
+							"FirstChild": "ptr:(nil)",
+							"LastChild": "ptr:(nil)",
+							"PrevSibling": "ptr:(ELEM ccc)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "CharDataNode",
+							"Data": "\n\t\t\t",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": null,
+							"Level": 3,
+							"#children": []
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM bbb)",
+					"NextSibling": "ptr:(ELEM ddd)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(ELEM eee)",
+					"LastChild": "ptr:(ELEM eee)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t\t')",
+					"NextSibling": "ptr:(CDATA '\n\t\t')",
+					"Type": "ElementNode",
+					"Data": "ddd",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": [
+						{
+							"Parent": "ptr:(ELEM ddd)",
+							"FirstChild": "ptr:(ELEM fff)",
+							"LastChild": "ptr:(ELEM fff)",
+							"PrevSibling": "ptr:(nil)",
+							"NextSibling": "ptr:(nil)",
+							"Type": "ElementNode",
+							"Data": "eee",
+							"Prefix": "",
+							"NamespaceURI": "",
+							"Attr": [],
+							"Level": 3,
+							"#children": [
+								{
+									"Parent": "ptr:(ELEM eee)",
+									"FirstChild": "ptr:(nil)",
+									"LastChild": "ptr:(nil)",
+									"PrevSibling": "ptr:(nil)",
+									"NextSibling": "ptr:(nil)",
+									"Type": "ElementNode",
+									"Data": "fff",
+									"Prefix": "",
+									"NamespaceURI": "",
+									"Attr": [],
+									"Level": 4,
+									"#children": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(ELEM ddd)",
+					"NextSibling": "ptr:(ELEM ggg)",
+					"Type": "CharDataNode",
+					"Data": "\n\t\t",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": null,
+					"Level": 2,
+					"#children": []
+				},
+				{
+					"Parent": "ptr:(ELEM aaa)",
+					"FirstChild": "ptr:(nil)",
+					"LastChild": "ptr:(nil)",
+					"PrevSibling": "ptr:(CDATA '\n\t\t')",
+					"NextSibling": "ptr:(nil)",
+					"Type": "ElementNode",
+					"Data": "ggg",
+					"Prefix": "",
+					"NamespaceURI": "",
+					"Attr": [],
+					"Level": 2,
+					"#children": []
+				}
+			]
+		}
+	]
+}
+

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.14
 
 require (
 	github.com/antchfx/xpath v1.1.6
+	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,16 @@
 github.com/antchfx/xpath v1.1.6 h1:6sVh6hB5T6phw1pFpHRQ+C4bd8sNI+O58flqtg7h0R0=
 github.com/antchfx/xpath v1.1.6/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
+github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -9,3 +18,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,108 @@
+package xmlquery
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+)
+
+// Produces a marshaling friendly name for a given *Node.
+func nodeName(n *Node) string {
+	if n == nil {
+		return "(nil)"
+	}
+	switch n.Type {
+	case DocumentNode:
+		return "(ROOT)"
+	case DeclarationNode:
+		return "(DECL)"
+	case ElementNode:
+		name := fmt.Sprintf("(ELEM %s)", n.Data)
+		if n.Prefix != "" {
+			name = fmt.Sprintf("(ELEM %s:%s)", n.Prefix, n.Data)
+		}
+		return name
+	case TextNode:
+		return fmt.Sprintf("(TEXT '%s')", n.Data)
+	case CharDataNode:
+		return fmt.Sprintf("(CDATA '%s')", n.Data)
+	case CommentNode:
+		return fmt.Sprintf("(COMMENT '%s')", n.Data)
+	case AttributeNode:
+		return fmt.Sprintf("(ATTR '%s')", n.Data)
+	default:
+		return fmt.Sprintf("(UNKNOWN '%s')", n.Data)
+	}
+}
+
+// We have to implement a custom json marshaler for Node given its self-referencing
+// pointers which would cause json marshaler infinite recursion and stack overflow.
+// Keep the marshaler in _test.go so it doesn't end up in production library code.
+func (n Node) MarshalJSON() ([]byte, error) {
+	ptrToStr := func(link *Node) string {
+		return "ptr:" + nodeName(link)
+	}
+	children := []*Node{}
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		children = append(children, child)
+	}
+	return json.Marshal(&struct {
+		Parent, FirstChild, LastChild, PrevSibling, NextSibling string
+		Type                                                    NodeType
+		Data                                                    string
+		Prefix                                                  string
+		NamespaceURI                                            string
+		Attr                                                    []xml.Attr
+		Level                                                   int
+		Children                                                []*Node `json:"#children"`
+	}{
+		Parent:       ptrToStr(n.Parent),
+		FirstChild:   ptrToStr(n.FirstChild),
+		LastChild:    ptrToStr(n.LastChild),
+		PrevSibling:  ptrToStr(n.PrevSibling),
+		NextSibling:  ptrToStr(n.NextSibling),
+		Type:         n.Type,
+		Data:         n.Data,
+		Prefix:       n.Prefix,
+		NamespaceURI: n.NamespaceURI,
+		Attr:         n.Attr,
+		Level:        n.level,
+		Children:     children,
+	})
+}
+
+// Make marshaling of NodeType (an int type) human readable.
+var nodeTypeStrings = map[NodeType]string{
+	DocumentNode:    "DocumentNode",
+	DeclarationNode: "DeclarationNode",
+	ElementNode:     "ElementNode",
+	TextNode:        "TextNode",
+	CharDataNode:    "CharDataNode",
+	CommentNode:     "CommentNode",
+	AttributeNode:   "AttributeNode",
+}
+
+func (nt NodeType) String() string {
+	if s, found := nodeTypeStrings[nt]; found {
+		return s
+	}
+	return fmt.Sprintf("(unknown:%d)", nt)
+}
+
+func (nt NodeType) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + nt.String() + `"`), nil
+}
+
+// A best-effort json marshaling helper for test
+func prettyJSONMarshal(v interface{}) string {
+	valueBuf := new(bytes.Buffer)
+	enc := json.NewEncoder(valueBuf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "\t")
+	err := enc.Encode(v)
+	if err != nil {
+		return "{}"
+	}
+	return valueBuf.String()
+}

--- a/node.go
+++ b/node.go
@@ -187,6 +187,34 @@ func addSibling(sibling, n *Node) {
 	}
 }
 
+// removes a node and its subtree from the tree it is in.
+// If the node is the root of the tree, then it's no-op.
+func removeFromTree(n *Node) {
+	if n.Parent == nil {
+		return
+	}
+	if n.Parent.FirstChild == n {
+		if n.Parent.LastChild == n {
+			n.Parent.FirstChild = nil
+			n.Parent.LastChild = nil
+		} else {
+			n.Parent.FirstChild = n.NextSibling
+			n.NextSibling.PrevSibling = nil
+		}
+	} else {
+		if n.Parent.LastChild == n {
+			n.Parent.LastChild = n.PrevSibling
+			n.PrevSibling.NextSibling = nil
+		} else {
+			n.PrevSibling.NextSibling = n.NextSibling
+			n.NextSibling.PrevSibling = n.PrevSibling
+		}
+	}
+	n.Parent = nil
+	n.PrevSibling = nil
+	n.NextSibling = nil
+}
+
 // LoadURL loads the XML document from the specified URL.
 func LoadURL(url string) (*Node, error) {
 	resp, err := http.Get(url)


### PR DESCRIPTION
This is pt1 of adding stream parser support. See original proof-of-concept PR at https://github.com/antchfx/xmlquery/pull/32.

- Add `removeFromTree` helper. This is needed during the stream parsing: every time when we load and match a target node, we must remove the previous target node from the DOM tree (or otherwise it defeats the purpose of stream parsing to avoid memory constraints)

- Add `*Node` and various type marshaling code in `marshal_test.go` for test snapshotting. The reason putting these in a `_test.go` file is to avoid adding them into the production code that would 'pollute' the library.

- Add dependencies to `testify` (for all the asserts) and `cupaloy` for test snapshots.

In the future, to update any test snapshots, simply add `UPDATE_SNAPSHOTS=true` env var:
```
UPDATE_SNAPSHOTS=true go test ./...
```