### PR TITLE
Stream Parser Support - pt3 - create `parser` context object and turn `parse()` function into `parser.parse()`

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -20,20 +20,6 @@ func LoadURL(url string) (*Node, error) {
 	return Parse(resp.Body)
 }
 
-// Parse returns the parse tree for the XML from the given Reader.
-func Parse(r io.Reader) (*Node, error) {
-	p := createParser(r)
-	for {
-		_, err := p.parse()
-		if err == io.EOF {
-			return p.doc, nil
-		}
-		if err != nil {
-			return nil, err
-		}
-	}
-}
-
 type parser struct {
 	decoder      *xml.Decoder
 	doc          *Node
@@ -160,6 +146,20 @@ func (p *parser) parse() (*Node, error) {
 			}
 			p.prev = node
 		case xml.Directive:
+		}
+	}
+}
+
+// Parse returns the parse tree for the XML from the given Reader.
+func Parse(r io.Reader) (*Node, error) {
+	p := createParser(r)
+	for {
+		_, err := p.parse()
+		if err == io.EOF {
+			return p.doc, nil
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 }


### PR DESCRIPTION
Stream Parser Support - pt3 - create `parser` context object and turn `parse()` function into `parser.parse()`

Eventually streaming parser needs to remember state in between client calls, thus we have to save those into a `parser` context object. This PR simply creates the `parser` context object and turns `parse()` the standalone function into a method on `parser` object. Move all the state variables into `parser` object. Other than that, the functionalities and code paths remain unchanged.