### PR TITLE
[FIX] Parsing XML from a URL

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -21,7 +21,7 @@ func LoadURL(url string) (*Node, error) {
 	}
 	defer resp.Body.Close()
 	// Make sure the Content-Type has a valid XML MIME type
-	regex := regexp.MustCompile(`(?i)(((application|image|message|model)/((\w|\.|-)+\+?))?|text/)(wb)?xml`)
+	regex := regexp.MustCompile(`(?i)((application|image|message|model)/((\w|\.|-)+\+?)?|text/)(wb)?xml`)
 	if regex.MatchString(resp.Header.Get("Content-Type")) {
 		return Parse(resp.Body)
 	}

--- a/parse.go
+++ b/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/antchfx/xpath"
@@ -19,12 +20,12 @@ func LoadURL(url string) (*Node, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	// Checking the HTTP Content-Type value from the response headers.(#39)
-	v := strings.ToLower(resp.Header.Get("Content-Type"))
-	if v == "text/xml" || v == "application/xml" {
+	// Make sure the Content-Type has a valid XML MIME type
+	regex := regexp.MustCompile(`(?i)(((application|image|message|model)/((\w|\.|-)+\+?))?|text/)(wb)?xml`)
+	if regex.MatchString(resp.Header.Get("Content-Type")) {
 		return Parse(resp.Body)
 	}
-	return nil, fmt.Errorf("invalid XML document(%s)", v)
+	return nil, fmt.Errorf("invalid XML document(%s)", resp.Header.Get("Content-Type"))
 }
 
 // Parse returns the parse tree for the XML from the given Reader.


### PR DESCRIPTION
## Problem
The [logic](https://github.com/antchfx/xmlquery/commit/5648b2f39e8d5d3fc903c45a4f1274829df71821#diff-090598d65549267a01d4ed4132809255R24) introduced to fix issue #39 does a very basic string check. Because only the exact `text/xml` and `application/xml` strings are considered valid, when the `Content-Type` header contains values such as `text/xml; charset=UTF-8` or `application/xml; charset=UTF-8`, we get an error.

Another problem is that there are other [XML MIME](https://en.wikipedia.org/wiki/XML_and_MIME) types besides those two.

If we do a quick search [here](https://www.iana.org/assignments/media-types/media-types.xhtml), we can find 400+ MIME types related to XML.

## Solution
The mime type check logic has been improved by using a regular expression. The only thing that might take longer to understand in the changes is the _regex_ itself, so here's a brief explanation:
```
(?i)  --> case insensitive matches (no need to convert the string to lowercase)
(
  (application|image|message|model) --> most of the types that make up an XML MIME type
  / --> type/subtype separator
  ((\w|\.|-)+\+?)?  --> this group may exist with characters (a-z, 0-9, _, . and -) (+ may not be there) at the start of a subtype
  |
  text --> remaining type that can be part of an XML MIME type
  / --> type/subtype separator
)
(wb)? --> Some XML MIME types might end in wbxml
xml --> the final part of the subtype
```

## Caveats
The current regular expression isn't strict about what types should go with sub types, which means that non-existent/unofficial MIME types, like `image/dash+xml` or `model/svg+xml` are considered valid.

For the sake of simplicity, I think that's a good trade-off. It also means that when new XML MIME types are added in the future, this logic should require low maintenance, if any.

## Task items:
- [X] Improve MIME type check logic in `LoadURL()`;
- [X] Update existing tests for success and add tests to fail;