### PR TITLE
Ensure CDATA tags are preserved across parses

### DIFF
--- a/cached_reader.go
+++ b/cached_reader.go
@@ -1,0 +1,69 @@
+package xmlquery
+
+import (
+	"bufio"
+)
+
+type cachedReader struct {
+	buffer *bufio.Reader
+	cache []byte
+	cacheCap int
+	cacheLen int
+	caching bool
+}
+
+func newCachedReader(r *bufio.Reader) *cachedReader {
+	return &cachedReader{
+		buffer:   r,
+		cache:    make([]byte, 4096),
+		cacheCap: 4096,
+		cacheLen: 0,
+		caching:  false,
+	}
+}
+
+func (c *cachedReader) StartCaching() {
+	c.cacheLen = 0
+	c.caching = true
+}
+
+func (c *cachedReader) ReadByte() (byte, error) {
+	if !c.caching {
+		return c.buffer.ReadByte()
+	}
+	b, err := c.buffer.ReadByte()
+	if err != nil {
+		return b, err
+	}
+	if c.cacheLen < c.cacheCap {
+		c.cache[c.cacheLen] = b
+		c.cacheLen++
+	}
+	return b, err
+}
+
+func (c *cachedReader) Cache() []byte {
+	return c.cache[:c.cacheLen]
+}
+
+func (c *cachedReader) StopCaching() {
+	c.caching = false
+}
+
+func (c *cachedReader) Read(p []byte) (int, error) {
+	n, err := c.buffer.Read(p)
+	if err != nil {
+		return n, err
+	}
+	if c.caching && c.cacheLen < c.cacheCap {
+		for i := 0; i < n; i++ {
+			c.cache[c.cacheLen] = p[i]
+			c.cacheLen++
+			if c.cacheLen >= c.cacheCap {
+				break
+			}
+		}
+	}
+	return n, err
+}
+

--- a/cached_reader_test.go
+++ b/cached_reader_test.go
@@ -1,0 +1,42 @@
+package xmlquery
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCaching(t *testing.T) {
+	buf := strings.NewReader(`ABCDEF`)
+	bufReader := bufio.NewReader(buf)
+	cachedReader := newCachedReader(bufReader)
+
+	b, err := cachedReader.ReadByte()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if b != 'A' {
+		t.Fatalf("Expected read byte to be A, got %c instead.", b)
+	}
+
+	cachedReader.StartCaching()
+	tmpBuf := make([]byte, 10)
+	n, err := cachedReader.Read(tmpBuf)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if n != 5 {
+		t.Fatalf("Expected 5 bytes to be read. Got %d instead.", n)
+	}
+	if !bytes.Equal(tmpBuf[:n], []byte("BCDEF")) {
+		t.Fatalf("Incorrect read buffer value")
+	}
+
+	cached := cachedReader.Cache()
+	if !bytes.Equal(cached, []byte("BCDEF")) {
+		t.Fatalf("Incorrect cached buffer value")
+	}
+}

--- a/node.go
+++ b/node.go
@@ -82,8 +82,13 @@ func calculatePreserveSpaces(n *Node, pastValue bool) bool {
 func outputXML(buf *bytes.Buffer, n *Node, preserveSpaces bool) {
 	preserveSpaces = calculatePreserveSpaces(n, preserveSpaces)
 	switch n.Type {
-	case TextNode, CharDataNode:
+	case TextNode:
 		xml.EscapeText(buf, []byte(n.sanitizedData(preserveSpaces)))
+		return
+	case CharDataNode:
+		buf.WriteString("<![CDATA[")
+		xml.EscapeText(buf, []byte(n.sanitizedData(preserveSpaces)))
+		buf.WriteString("]]>")
 		return
 	case CommentNode:
 		buf.WriteString("<!--")

--- a/parse_test.go
+++ b/parse_test.go
@@ -94,7 +94,7 @@ func TestNamespaceURL(t *testing.T) {
 <?xml version="1.0"?>
 <rss version="2.0" xmlns="http://www.example.com/" xmlns:dc="https://purl.org/dc/elements/1.1/">
 <!-- author -->
-<dc:creator><![CDATA[Richard Lawler]]></dc:creator>
+<dc:creator><![CDATA[Richard ]]><![CDATA[Lawler]]></dc:creator>
 <dc:identifier>21|22021348</dc:identifier>
 </rss>
 	`
@@ -455,4 +455,22 @@ func TestStreamParser_Success2(t *testing.T) {
 	if err != io.EOF {
 		t.Fatalf("io.EOF expected, but got %v", err)
 	}
+}
+
+func TestCDATA(t *testing.T) {
+	s := `
+	<AAA>
+		<CCC><![CDATA[c1]]></CCC>
+	</AAA>`
+
+	sp, err := CreateStreamParser(strings.NewReader(s), "/AAA/CCC")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	n, err := sp.Read()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	testOutputXML(t, "first call result", `<CCC><![CDATA[c1]]></CCC>`, n)
 }


### PR DESCRIPTION
Hi there! First, thank you for the effort on maintaining this library. Using `xml.Decoder` alone would be at least terrible.
Since I'm using it, this is a small contribution to give back to the community.

This implements a new `cachedReader` that will maintain the last 4096 bytes between `StartCaching` and `StopCaching` calls. Leveraging the call sequence of `xml.Decoder.Token()`, we can realiably detect CDATA tags, and act accordingly. This should also work well with streams, again, given how `xml.Decoder.Token()` returns data.
I also edited a test to ensure we maintain compatibility.

Thank you!