### PR TITLE
Augment CI matrix for new Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.9.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
 
 install:
   - go get golang.org/x/net/html/charset


### PR DESCRIPTION
This adds Go 1.14 and 1.15 to Travis Build Matrix