### PR TITLE
Allowing injecting custom-configured decoder instance

### DIFF
--- a/cached_reader.go
+++ b/cached_reader.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 )
 
-type cachedReader struct {
+type CachedReader struct {
 	buffer *bufio.Reader
 	cache []byte
 	cacheCap int
@@ -12,8 +12,8 @@ type cachedReader struct {
 	caching bool
 }
 
-func newCachedReader(r *bufio.Reader) *cachedReader {
-	return &cachedReader{
+func NewCachedReader(r *bufio.Reader) *CachedReader {
+	return &CachedReader{
 		buffer:   r,
 		cache:    make([]byte, 4096),
 		cacheCap: 4096,
@@ -22,12 +22,12 @@ func newCachedReader(r *bufio.Reader) *cachedReader {
 	}
 }
 
-func (c *cachedReader) StartCaching() {
+func (c *CachedReader) StartCaching() {
 	c.cacheLen = 0
 	c.caching = true
 }
 
-func (c *cachedReader) ReadByte() (byte, error) {
+func (c *CachedReader) ReadByte() (byte, error) {
 	if !c.caching {
 		return c.buffer.ReadByte()
 	}
@@ -42,15 +42,15 @@ func (c *cachedReader) ReadByte() (byte, error) {
 	return b, err
 }
 
-func (c *cachedReader) Cache() []byte {
+func (c *CachedReader) Cache() []byte {
 	return c.cache[:c.cacheLen]
 }
 
-func (c *cachedReader) StopCaching() {
+func (c *CachedReader) StopCaching() {
 	c.caching = false
 }
 
-func (c *cachedReader) Read(p []byte) (int, error) {
+func (c *CachedReader) Read(p []byte) (int, error) {
 	n, err := c.buffer.Read(p)
 	if err != nil {
 		return n, err

--- a/cached_reader_test.go
+++ b/cached_reader_test.go
@@ -10,9 +10,9 @@ import (
 func TestCaching(t *testing.T) {
 	buf := strings.NewReader(`ABCDEF`)
 	bufReader := bufio.NewReader(buf)
-	cachedReader := newCachedReader(bufReader)
+	CachedReader := NewCachedReader(bufReader)
 
-	b, err := cachedReader.ReadByte()
+	b, err := CachedReader.ReadByte()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -21,9 +21,9 @@ func TestCaching(t *testing.T) {
 		t.Fatalf("Expected read byte to be A, got %c instead.", b)
 	}
 
-	cachedReader.StartCaching()
+	CachedReader.StartCaching()
 	tmpBuf := make([]byte, 10)
-	n, err := cachedReader.Read(tmpBuf)
+	n, err := CachedReader.Read(tmpBuf)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -35,7 +35,7 @@ func TestCaching(t *testing.T) {
 		t.Fatalf("Incorrect read buffer value")
 	}
 
-	cached := cachedReader.Cache()
+	cached := CachedReader.Cache()
 	if !bytes.Equal(cached, []byte("BCDEF")) {
 		t.Fatalf("Incorrect cached buffer value")
 	}

--- a/parse.go
+++ b/parse.go
@@ -32,7 +32,14 @@ func LoadURL(url string) (*Node, error) {
 
 // Parse returns the parse tree for the XML from the given Reader.
 func Parse(r io.Reader) (*Node, error) {
-	p := createParser(r)
+	reader := NewCachedReader(bufio.NewReader(r))
+	decoder := xml.NewDecoder(reader)
+	return ParseWithDecoder(reader, decoder)
+}
+
+// ParseWithDecoder is identical to Parse, but uses the given reader and decoder
+func ParseWithDecoder(reader *CachedReader, decoder *xml.Decoder) (*Node, error) {
+	p := createParser(reader, decoder)
 	for {
 		_, err := p.parse()
 		if err == io.EOF {
@@ -54,13 +61,12 @@ type parser struct {
 	streamElementFilter *xpath.Expr   // If specified, it provides further filtering on the target element.
 	streamNode          *Node         // Need to remember the last target node So we can clean it up upon next Read() call.
 	streamNodePrev      *Node         // Need to remember target node's prev so upon target node removal, we can restore correct prev.
-	reader              *cachedReader // Need to maintain a reference to the reader, so we can determine whether a node contains CDATA.
+	reader              *CachedReader // Need to maintain a reference to the reader, so we can determine whether a node contains CDATA.
 }
 
-func createParser(r io.Reader) *parser {
-	reader := newCachedReader(bufio.NewReader(r))
+func createParser(reader *CachedReader, decoder *xml.Decoder) *parser {
 	p := &parser{
-		decoder:      xml.NewDecoder(reader),
+		decoder:      decoder,
 		doc:          &Node{Type: DocumentNode},
 		space2prefix: make(map[string]string),
 		level:        0,
@@ -301,6 +307,19 @@ type StreamParser struct {
 // streamElementFilter, if provided, cannot be successfully parsed and compiled
 // into a valid xpath query.
 func CreateStreamParser(r io.Reader, streamElementXPath string, streamElementFilter ...string) (*StreamParser, error) {
+	reader := NewCachedReader(bufio.NewReader(r))
+	decoder := xml.NewDecoder(reader)
+	return CreateStreamParserWithDecoder(reader, decoder, streamElementXPath, streamElementFilter...)
+}
+
+// CreateStreamParserWithDecoder is identical to CreateStreamParser,
+// but uses the given reader and decoder
+func CreateStreamParserWithDecoder(
+	reader *CachedReader,
+	decoder *xml.Decoder,
+	streamElementXPath string,
+	streamElementFilter ...string,
+) (*StreamParser, error) {
 	elemXPath, err := getQuery(streamElementXPath)
 	if err != nil {
 		return nil, fmt.Errorf("invalid streamElementXPath '%s', err: %s", streamElementXPath, err.Error())
@@ -313,7 +332,7 @@ func CreateStreamParser(r io.Reader, streamElementXPath string, streamElementFil
 		}
 	}
 	sp := &StreamParser{
-		p: createParser(r),
+		p: createParser(reader, decoder),
 	}
 	sp.p.streamElementXPath = elemXPath
 	sp.p.streamElementFilter = elemFilter


### PR DESCRIPTION
Hello, and thank you for this package.

For my usecase, I need to set the decoder settings to `Strict = false`. I saw that you commented [here](https://github.com/antchfx/xmlquery/pull/27#issuecomment-584474917), and made the suggested changes. If you were to merge this, you can probably close #27 .

Since the decoder needs to be injected a `cachedReader`, I did not find any other way than exposing the `cachedReader` object.

This change also happens to help with my usecase, because I want to be able to jump to any element from it's offset (during a stream-parse) with `reader.Seek`, which breaks the caching system unless I can empty it.