### PR TITLE
Fixed memory leak issue during stream-parse

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -331,8 +331,15 @@ func (sp *StreamParser) Read() (*Node, error) {
 	// Because this is a streaming read, we need to release/remove last
 	// target node from the node tree to free up memory.
 	if sp.p.streamNode != nil {
+		// We need to remove all siblings before the current stream node,
+		// because the document may contain unwanted nodes between the target
+		// ones (for example new line text node), which would otherwise
+		// accumulate as first childs, and slow down the stream over time
+		for sp.p.streamNode.PrevSibling != nil {
+			RemoveFromTree(sp.p.streamNode.PrevSibling)
+		}
+		sp.p.prev = sp.p.streamNode.Parent
 		RemoveFromTree(sp.p.streamNode)
-		sp.p.prev = sp.p.streamNodePrev
 		sp.p.streamNode = nil
 		sp.p.streamNodePrev = nil
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -379,7 +379,7 @@ func TestStreamParser_Success1(t *testing.T) {
 	}
 	testOutputXML(t, "second call result", `<BBB>b2<ZZZ z="1">z1</ZZZ></BBB>`, n)
 	testOutputXML(t, "doc after second call",
-		`<><?xml?><ROOT><AAA><CCC>c1</CCC><DDD>d1</DDD><BBB>b2<ZZZ z="1">z1</ZZZ></BBB></AAA></ROOT></>`, findRoot(n))
+		`<><?xml?><ROOT><AAA><DDD>d1</DDD><BBB>b2<ZZZ z="1">z1</ZZZ></BBB></AAA></ROOT></>`, findRoot(n))
 
 	// Third `<BBB>` read (Note we will skip 'b3' since the streamElementFilter excludes it)
 	n, err = sp.Read()
@@ -391,7 +391,7 @@ func TestStreamParser_Success1(t *testing.T) {
 	// been filtered out and is not our target node, thus it is considered just like any other
 	// non target nodes such as `<CCC>`` or `<DDD>`
 	testOutputXML(t, "doc after third call",
-		`<><?xml?><ROOT><AAA><CCC>c1</CCC><DDD>d1</DDD></AAA><ZZZ><BBB>b4</BBB></ZZZ></ROOT></>`,
+		`<><?xml?><ROOT><AAA></AAA><ZZZ><BBB>b4</BBB></ZZZ></ROOT></>`,
 		findRoot(n))
 
 	// Fourth `<BBB>` read
@@ -401,7 +401,7 @@ func TestStreamParser_Success1(t *testing.T) {
 	}
 	testOutputXML(t, "fourth call result", `<BBB>b5</BBB>`, n)
 	testOutputXML(t, "doc after fourth call",
-		`<><?xml?><ROOT><AAA><CCC>c1</CCC><DDD>d1</DDD></AAA><ZZZ><BBB>b5</BBB></ZZZ></ROOT></>`,
+		`<><?xml?><ROOT><AAA></AAA><ZZZ><BBB>b5</BBB></ZZZ></ROOT></>`,
 		findRoot(n))
 
 	_, err = sp.Read()
@@ -449,7 +449,7 @@ func TestStreamParser_Success2(t *testing.T) {
 	}
 	testOutputXML(t, "third call result", `<CCC>c2</CCC>`, n)
 	testOutputXML(t, "doc after third call",
-		`<><?xml?><AAA><BBB>b1</BBB><BBB>b2</BBB><CCC>c2</CCC></AAA></>`, findRoot(n))
+		`<><?xml?><AAA><BBB>b2</BBB><CCC>c2</CCC></AAA></>`, findRoot(n))
 
 	_, err = sp.Read()
 	if err != io.EOF {


### PR DESCRIPTION
During stream-parse, the parser only deletes the previous element from the node to free memory. However, this is not accounting for any unwanted nodes between the targets. For example, if there is a new line character between tags, those TextNodes did not get cleaned.

After each iteration, a new TextNode was getting added as previous siblings of the next target, causing the performance to slow down with the number of elements parsed.

In my case, after 10k elements, the parser would have to first iterate over 10k TextNodes, which makes impossible to stream-parse large documents.