### PR TITLE
Skip text node only if empty

### DIFF
--- a/query.go
+++ b/query.go
@@ -277,7 +277,7 @@ func (x *NodeNavigator) MoveToNext() bool {
 	}
 	for node := x.curr.NextSibling; node != nil; node = x.curr.NextSibling {
 		x.curr = node
-		if x.curr.Type != TextNode {
+		if x.curr.Type != TextNode || strings.TrimSpace(x.curr.Data) != "" {
 			return true
 		}
 	}
@@ -290,7 +290,7 @@ func (x *NodeNavigator) MoveToPrevious() bool {
 	}
 	for node := x.curr.PrevSibling; node != nil; node = x.curr.PrevSibling {
 		x.curr = node
-		if x.curr.Type != TextNode {
+		if x.curr.Type != TextNode || strings.TrimSpace(x.curr.Data) != "" {
 			return true
 		}
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -159,3 +159,14 @@ func loadXML(s string) *Node {
 	}
 	return node
 }
+
+func TestMissingTextNodes(t *testing.T) {
+    doc := loadXML(`
+        <?xml version="1.0" encoding="utf-8"?>
+        <corpus><p>Lorem <a>ipsum</a> dolor</p></corpus>
+    `)
+    results := Find(doc, "//text()")
+    if len(results) != 3 {
+        t.Fatalf("Expected text nodes 3, got %d", len(results))
+    }
+}


### PR DESCRIPTION
The fix in #45 skips non empty text nodes and results in the issue i reported in #61. This PR will skip only empty text nodes. I just used `strings.TrimSpace()` which will trim more than XSLT defines as non preserving whitespace. But this is probably the behaviour most users would expect. Otherwise i could only check for LF, CR, SP and HT.