### PR TITLE
fix: when node is root, not output unnecessary string

### DIFF
--- a/node.go
+++ b/node.go
@@ -142,7 +142,7 @@ func outputXML(buf *bytes.Buffer, n *Node, preserveSpaces bool) {
 func (n *Node) OutputXML(self bool) string {
 	preserveSpaces := calculatePreserveSpaces(n, false)
 	var buf bytes.Buffer
-	if self {
+	if self && n.Type != DocumentNode {
 		outputXML(&buf, n, preserveSpaces)
 	} else {
 		for n := n.FirstChild; n != nil; n = n.NextSibling {


### PR DESCRIPTION
When I use `OutputXML` to copy a xml document I found When the node is root , this function will print unnecessary `<>` and `<>`。


```go
s := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"></rss>`
doc, err := xmlquery.Parse(strings.NewReader(s))

log.Printf(doc.OutputXML(true))
// will print this:
//`<><?xml version="1.0" encoding="utf-8"?><rss version="2.0"></rss></>`
```

I not sure, if this is run as you expected. I think this may be not right behavior, so I create this pr.