### PR TITLE
only escape characters xml need to be escaped

### DIFF
--- a/node.go
+++ b/node.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"html"
 	"strings"
 )
 
@@ -89,7 +90,7 @@ func outputXML(buf *bytes.Buffer, n *Node, preserveSpaces bool) {
 	preserveSpaces = calculatePreserveSpaces(n, preserveSpaces)
 	switch n.Type {
 	case TextNode:
-		xml.EscapeText(buf, []byte(n.sanitizedData(preserveSpaces)))
+		buf.WriteString(html.EscapeString(n.sanitizedData(preserveSpaces)))
 		return
 	case CharDataNode:
 		buf.WriteString("<![CDATA[")
@@ -118,7 +119,7 @@ func outputXML(buf *bytes.Buffer, n *Node, preserveSpaces bool) {
 			buf.WriteString(fmt.Sprintf(` %s=`, attr.Name.Local))
 		}
 		buf.WriteByte('"')
-		xml.EscapeText(buf, []byte(attr.Value))
+		buf.WriteString(html.EscapeString(attr.Value))
 		buf.WriteByte('"')
 	}
 	if n.Type == DeclarationNode {

--- a/node_test.go
+++ b/node_test.go
@@ -280,6 +280,31 @@ func TestEscapeOutputValue(t *testing.T) {
 
 }
 
+func TestUnnecessaryEscapeOutputValue(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list xml:space="preserve">
+		<student>
+			<name> Robert </name>
+			<grade>A+</grade>
+
+		</student>
+	</class_list>`
+
+	root, err := Parse(strings.NewReader(data))
+	if err != nil {
+		t.Error(err)
+	}
+
+	escapedInnerText := root.OutputXML(true)
+	if strings.Contains(escapedInnerText, "&#x9") {
+		t.Fatal("\\n has been escaped unnecessarily")
+	}
+
+	if strings.Contains(escapedInnerText, "&#xA") {
+		t.Fatal("\\t has been escaped unnecessarily")
+	}
+
+}
 func TestOutputXMLWithNamespacePrefix(t *testing.T) {
 	s := `<?xml version="1.0" encoding="UTF-8"?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body></S:Body></S:Envelope>`
 	doc, _ := Parse(strings.NewReader(s))

--- a/node_test.go
+++ b/node_test.go
@@ -305,6 +305,28 @@ func TestUnnecessaryEscapeOutputValue(t *testing.T) {
 	}
 
 }
+
+func TestHtmlUnescapeStringOriginString(t *testing.T) {
+	// has escape html character and \t
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<example xml:space="preserve"><word>&amp;#48;		</word></example>`
+
+	root, err := Parse(strings.NewReader(data))
+	if err != nil {
+		t.Error(err)
+	}
+
+	escapedInnerText := root.OutputXML(false)
+	unescapeString := html.UnescapeString(escapedInnerText)
+	if strings.Contains(unescapeString, "&amp;") {
+		t.Fatal("&amp; need unescape")
+	}
+	if !strings.Contains(escapedInnerText, "&amp;#48;\t\t") {
+		t.Fatal("Inner Text should keep plain text")
+	}
+
+}
+
 func TestOutputXMLWithNamespacePrefix(t *testing.T) {
 	s := `<?xml version="1.0" encoding="UTF-8"?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body></S:Body></S:Envelope>`
 	doc, _ := Parse(strings.NewReader(s))


### PR DESCRIPTION
as I mentioned at #73 , escape `/n/t` is not necessary. These words is allowed to be saved at XML。

>I think it's quite strange that while `html.EscapeString` replace the `XML` escape characters, `xml.EscapeText` escape more characters than XML allow.

After merge this pr

## `/t/n` will show it origin characters

 when developer read a xml
```xml
<?xml version="1.0" encoding="utf-8"?>
	<class_list xml:space="preserve">
		<student>
			<name> Robert </name>
			<grade>A+</grade>

		</student>
	</class_list>
`
```

doc `OutputXML` will give developer as it was, and it comply with xml specification

before this pr was merge , `OutputXML` will give human unreadable like this:
`<?xml version=\"1.0\" encoding=\"utf-8\"?><class_list xml:space=\"preserve\">&#xA;&#x9;&#x9;<student>&#xA;&#x9;&#x9;&#x9;<name> Robert </name>&#xA;&#x9;&#x9;&#x9;<grade>A+</grade>&#xA;&#xA;&#x9;&#x9;</student>&#xA;&#x9;</class_list>`

## fix some xml never get origin plain text

before this pr,  we need call `html.UnescapeString` to print the origin plain text
but there is some xml you may never get origin plain text by `html.UnescapeString` like this xml below
```
<?xml version="1.0" encoding="utf-8"?>
	<example xml:space="preserve"><word>&amp;#48;		</word></example>
```

you either get plain text `<?xml version=\"1.0\" encoding=\"utf-8\"?><class_list xml:space=\"preserve\">&#xA;&#x9;&#x9;<student>&#xA;&#x9;&#x9;&#x9;<name> Robert </name>&#xA;&#x9;&#x9;&#x9;<grade>A+</grade>&#xA;&#xA;&#x9;&#x9;</student>&#xA;&#x9;</class_list>` by `OutputXML`.

or get `<?xml version=\"1.0\" encoding=\"utf-8\"?><example xml:space=\"preserve\"><word>&#48;\t\t</word></example>` by `OutputXML` + `html.UnescapeString`. None of them are consistent with the original document

