### PR TITLE
fix strict mode did not affect namespace check

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -107,7 +107,7 @@ func (p *parser) parse() (*Node, error) {
 			}
 
 			if tok.Name.Space != "" {
-				if _, found := p.space2prefix[tok.Name.Space]; !found {
+				if _, found := p.space2prefix[tok.Name.Space]; !found && p.decoder.Strict {
 					return nil, errors.New("xmlquery: invalid XML document, namespace is missing")
 				}
 			}


### PR DESCRIPTION
Decoder's strict mode parameter does not respect default xml decoder behavior: turning off strict mode does not ignore missing namespaces. 
Therefore additional check for mode when verifying namespace exists for the token.