### PR TITLE
add WithPreserveSpace option when OutputXMLWithOptions

### DIFF
--- a/node.go
+++ b/node.go
@@ -80,6 +80,13 @@ func WithoutComments() OutputOption {
 	}
 }
 
+// WithPreserveSpace will preserve spaces in output
+func WithPreserveSpace() OutputOption {
+	return func(oc *outputConfiguration) {
+		oc.preserveSpaces = true
+	}
+}
+
 func newXMLName(name string) xml.Name {
 	if i := strings.IndexByte(name, ':'); i > 0 {
 		return xml.Name{
@@ -216,8 +223,11 @@ func (n *Node) OutputXMLWithOptions(opts ...OutputOption) string {
 	for _, opt := range opts {
 		opt(config)
 	}
+	pastPreserveSpaces := config.preserveSpaces
+	// restore the default value, for compatibility
+	config.preserveSpaces = false
 
-	preserveSpaces := calculatePreserveSpaces(n, false)
+	preserveSpaces := calculatePreserveSpaces(n, pastPreserveSpaces)
 	var b strings.Builder
 	if config.printSelf && n.Type != DocumentNode {
 		outputXML(&b, n, preserveSpaces, config)

--- a/node_test.go
+++ b/node_test.go
@@ -592,3 +592,22 @@ func TestOutputXMLWithOptions(t *testing.T) {
 		t.Errorf("output was not expected. expected %v but got %v", expected, result)
 	}
 }
+
+func TestOutputXMLWithPreserveSpaceOption(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?>
+	<class_list>
+		<student>
+			<name> Robert </name>
+			<grade>A+</grade>
+		</student>
+	</class_list>`
+	doc, _ := Parse(strings.NewReader(s))
+	resultWithSpace := doc.OutputXMLWithOptions(WithPreserveSpace())
+	resultWithoutSpace := doc.OutputXMLWithOptions()
+	if !strings.Contains(resultWithSpace, "> Robert <") {
+		t.Errorf("output was not expected. expected %v but got %v", " Robert ", resultWithSpace)
+	}
+	if !strings.Contains(resultWithoutSpace, ">Robert<") {
+		t.Errorf("output was not expected. expected %v but got %v", " Robert ", resultWithoutSpace)
+	}
+}


### PR DESCRIPTION
some XML like Office OpenXML can't to set `xml:space` attribute,  because it is generated by Word/PowerPoint/Excel, but there are spaces need to preserve after process.
the `WithPreserveSpace` is a option can be passed to `OutputXMLWithOptions` function, it set default value for `calculatePreserveSpaces` to `true` instead hard code `false`.