### PR TITLE
Add indentation support to XML output

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -612,6 +612,22 @@ func TestOutputXMLWithPreserveSpaceOption(t *testing.T) {
 	}
 }
 
+func TestOutputXMLWithIndentation(t *testing.T) {
+	s := `<?xml version="1.0" encoding="utf-8"?><xml><outerTag><tagWithValue>123</tagWithValue></outerTag></xml>`
+	expected := `<?xml version="1.0" encoding="utf-8"?>
+<xml>
+  <outerTag>
+    <tagWithValue>123</tagWithValue>
+  </outerTag>
+</xml>`
+
+	doc, _ := Parse(strings.NewReader(s))
+	resultWithIndent := doc.OutputXMLWithOptions(WithIndentation("  "))
+	if resultWithIndent != expected {
+		t.Errorf("output was not expected. expected %v but got %v", expected, resultWithIndent)
+	}
+}
+
 func TestNodeLevel(t *testing.T) {
 	s := `<?xml version="1.0" encoding="utf-8"?>
 	<class_list>


### PR DESCRIPTION
Introduce the new output option `WithIndentation(indentation string)` to support custom indentation in XML output. Updated `outputXML` function to handle indentation level and apply it to nested nodes.

**Why?**

I need to convert one line XML files to human readable files and implemented indentation support.