### PR TITLE
Support single quotes in attribute for the declaration node

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -658,3 +658,13 @@ func TestDirectiveNode(t *testing.T) {
 		t.Errorf(`expected "%s", obtained "%s"`, expected, v)
 	}
 }
+
+func TestOutputXMLWithSingleQuotes(t *testing.T) {
+	s := `<?xml version='1.0' encoding='utf-8'?><a><b c='d'></b></a>`
+	expected := `<?xml version="1.0" encoding="utf-8"?><a><b c="d"></b></a>`
+	doc, _ := Parse(strings.NewReader(s))
+	output := doc.OutputXML(false)
+	if expected != output {
+		t.Errorf(`expected "%s", obtained "%s"`, expected, output)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -266,7 +266,7 @@ func (p *parser) parse() (*Node, error) {
 			for _, pair := range pairs {
 				pair = strings.TrimSpace(pair)
 				if i := strings.Index(pair, "="); i > 0 {
-					AddAttr(node, pair[:i], strings.Trim(pair[i+1:], `"`))
+					AddAttr(node, pair[:i], strings.Trim(pair[i+1:], `"'`))
 				}
 			}
 			if p.level == p.prev.level {


### PR DESCRIPTION
I found a bug where parsing a declaration node that uses single quotes for its attributes would result in wrong values in the attribute list, causing the input:

`<?xml version='1.0' encoding='utf-8'?>`

To generate the following output:
`<?xml version="&#39;1.0&#39;" encoding="&#39;utf-8&#39;"?>`

I modified the `AddAttr` function to trim both double and single quotes from attribute values. Added a test to ensure XML attributes with single quotes are correctly parsed.